### PR TITLE
LIMS-1917 Inconsistencies related to significant digits in uncertainties

### DIFF
--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -82,7 +82,7 @@ class ajaxCalculateAnalysisEntry(BrowserView):
         mapping = {}
 
         # values to be returned to form for this UID
-        Result = {'uid': uid, 'result': form_result, 'result_str': self.value}
+        Result = {'uid': uid, 'result': form_result}
         try:
             Result['result'] = float(form_result)
         except:

--- a/bika/lims/browser/js/bika.lims.utils.calcs.js
+++ b/bika/lims/browser/js/bika.lims.utils.calcs.js
@@ -195,16 +195,7 @@ function CalculationUtils() {
                     // put result values in their boxes
                     for(i=0;i<$(data['results']).length;i++){
                         result = $(data['results'])[i];
-                        // We have to get the decimals because if they are .0, the will be ignored
-                        var decimals = 0;
-                        if (result.result_str.indexOf(".") > -1){
-                            decimals = result.result_str.split('.')[1].length;
-                        }
-                        var result_with_decimals = ""
-                        if (result.result_str != "" && result.result_str != ''){
-                            result_with_decimals = parseFloat(result.result_str).toFixed(decimals)
-                        };
-                        $("input[uid='"+result.uid+"']").filter("input[field='Result']").val(result_with_decimals);
+                         $("input[uid='"+result.uid+"']").filter("input[field='Result']").val(result.formatted_result);
 
                         $('[type="hidden"]').filter("[field='ResultDM']").filter("[uid='"+result.uid+"']").val(result.dry_result);
                         $($('[type="hidden"]').filter("[field='ResultDM']").filter("[uid='"+result.uid+"']").siblings()[0]).empty().append(result.dry_result);

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -439,10 +439,12 @@ class Analysis(BaseContent):
         return dep_analyses
 
     def setResult(self, value, **kw):
+        """ :value: must be a string
+        """
         # Always update ResultCapture date when this field is modified
         self.setResultCaptureDate(DateTime())
         # Only allow DL if manually enabled in AS
-        val = value
+        val = str(value)
         if val and (val.strip().startswith('>') or val.strip().startswith('<')):
             self.Schema().getField('DetectionLimitOperand').set(self, None)
             oper = '<' if val.strip().startswith('<') else '>'

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -927,9 +927,10 @@ class Analysis(BaseContent):
             # Drop trailing zeros from decimal
             udl = drop_trailing_zeros_decimal(udl)
             return formatDecimalMark('> %s' % udl, decimalmark)
-
         # Render numerical values
-        return formatDecimalMark(format_numeric_result(self, result, sciformat=sciformat), decimalmark=decimalmark)
+        return format_numeric_result(self, self.getResult(),
+                        decimalmark=decimalmark,
+                        sciformat=sciformat)
 
     def getPrecision(self, result=None):
         """

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -126,7 +126,7 @@ class TestCalculations(BikaFunctionalTestCase):
             },
         ]
         # New formulas for precision testing
-        self.formulas_precission = [
+        self.formulas_precision = [
             {'formula' : '[Ca]/[Mg]',
              'analyses': {'Ca':'10', 'Mg': '15'},
              'interims': {},
@@ -152,31 +152,15 @@ class TestCalculations(BikaFunctionalTestCase):
             ],
             'test_uncertainties_precision':[
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0, 'intercept_max': 10, 'errorvalue': 0.056},
                         ],
-                        'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                        'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ]
+                    'expected_result': '0.67'
                     },
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0.002, 'intercept_max': 20, 'errorvalue': 0.1}
                         ],
-                    'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                    'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ],
-                     },
+                    'expected_result': '0.7'
+                    },
                 ],
             },
             {'formula' : '[Ca]/[Mg]*[IN1]',
@@ -204,30 +188,16 @@ class TestCalculations(BikaFunctionalTestCase):
             ],
             'test_uncertainties_precision':[
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0, 'intercept_max': 10, 'errorvalue': 0.1},
+                        {'intercept_min': 11, 'intercept_max': 20, 'errorvalue': 0.056}
                         ],
-                        'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                        'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ]
+                    'expected_result': '0.6'
                     },
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0.1, 'intercept_max': 0.6, 'errorvalue': 0.1},
+                        {'intercept_min': 0.66, 'intercept_max': 20, 'errorvalue': 0.056}
                         ],
-                    'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                    'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ],
+                    'expected_result': '0.6',
                      },
                 ],
             },
@@ -256,31 +226,43 @@ class TestCalculations(BikaFunctionalTestCase):
             ],
             'test_uncertainties_precision':[
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0, 'intercept_max': 10, 'errorvalue': 0.1},
+                        {'intercept_min': 11, 'intercept_max': 20, 'errorvalue': 0.056}
                         ],
-                        'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                        'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ]
+                    'expected_result': '10.0'
                     },
+                ],
+            },
+            {'formula' : '[Ca]/[Mg]',
+             'analyses': {'Ca':'1', 'Mg': '20'},
+             'interims': {},
+             'test_fixed_precision': [
+                {'fixed_precision': 5,
+                 'expected_result': '0.05000',
+                },
+                {'fixed_precision': 2,
+                 'expected_result': '0.05'
+                },
+                {'fixed_precision': 1,
+                 'expected_result': '0.1'
+                },
+                {'fixed_precision': 0,
+                 'expected_result': '0'
+                },
+                {'fixed_precision': -1,
+                 'expected_result': '0'
+                },
+                {'fixed_precision': -5,
+                 'expected_result': '0'
+                },
+            ],
+            'test_uncertainties_precision':[
                     {'uncertainties': [
-                            [ 0, 10, 0.1   ],
-                            [11, 20, 0.056 ],
+                        {'intercept_min': 0, 'intercept_max': 0.01, 'errorvalue': 0.01},
+                        {'intercept_min': 11, 'intercept_max': 20, 'errorvalue': 0.056}
                         ],
-                    'analyses': [
-                            {'Ca': '12', 'Mg': '13'},
-                            {'Ca': '12', 'Mg': '13'},
-                        ],
-                    'expected_results': [
-                            '23.2',
-                            '32.3',
-                        ],
-                     },
+                    'expected_result': '0.05'
+                    },
                 ],
             },
 
@@ -375,7 +357,7 @@ class TestCalculations(BikaFunctionalTestCase):
         # SampleType:   Apple Pulp
         # Contact:      Rita Mohale
         # Analyses:     [Calcium, Mg, Total Hardness]
-        for f in self.formulas_precission:
+        for f in self.formulas_precision:
             self.calculation.setFormula(f['formula'])
             self.assertEqual(self.calculation.getFormula(), f['formula'])
             interims = []
@@ -444,7 +426,80 @@ class TestCalculations(BikaFunctionalTestCase):
                 self.assertEqual(calcanalysis.getFormattedResult(), case['expected_result'])
 
     def test_calculation_uncertainties_precision(self):
-        pass
+        # Input results
+        # Client:       Happy Hills
+        # SampleType:   Apple Pulp
+        # Contact:      Rita Mohale
+        # Analyses:     [Calcium, Mg, Total Hardness]
+        for f in self.formulas_precision:
+            self.calculation.setFormula(f['formula'])
+            self.assertEqual(self.calculation.getFormula(), f['formula'])
+            interims = []
+            for k,v in f['interims'].items():
+                interims.append({'keyword': k, 'title':k, 'value': v,
+                                 'hidden': False, 'type': 'int',
+                                 'unit': ''});
+            self.calculation.setInterimFields(interims)
+            self.assertEqual(self.calculation.getInterimFields(), interims)
+
+            for case in f['test_uncertainties_precision']:
+                # Define precision
+                services_obj = [s for s in self.services] + [self.calcservice]
+
+                for service in services_obj:
+                    service.setPrecisionFromUncertainty(True)
+                    service.setUncertainties(case['uncertainties'])
+                # Create the AR
+                client = self.portal.clients['client-1']
+                sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
+                values = {'Client': client.UID(),
+                          'Contact': client.getContacts()[0].UID(),
+                          'SamplingDate': '2015-01-01',
+                          'SampleType': sampletype.UID()}
+                request = {}
+                services = [s.UID() for s in self.services] + [self.calcservice.UID()]
+                ar = create_analysisrequest(client, request, values, services)
+                wf = getToolByName(ar, 'portal_workflow')
+                wf.doActionFor(ar, 'receive')
+
+                # Set results and interims
+                calcanalysis = None
+                for an in ar.getAnalyses():
+                    an = an.getObject()
+                    key = an.getKeyword()
+                    if key in f['analyses']:
+                        an.setResult(f['analyses'][key])
+                        if an.isLowerDetectionLimit() \
+                            or an.isUpperDetectionLimit():
+                            operator = an.getDetectionLimitOperand()
+                            strres = f['analyses'][key].replace(operator, '')
+                            self.assertEqual(an.getResult(), str(float(strres)))
+                        else:
+                            # The analysis' results have to be always strings
+                            self.assertEqual(an.getResult(), str(f['analyses'][key]))
+                    elif key == self.calcservice.getKeyword():
+                        calcanalysis = an
+
+                    # Set interims
+                    interims = an.getInterimFields()
+                    intermap = []
+                    for i in interims:
+                        if i['keyword'] in f['interims']:
+                            ival = float(f['interims'][i['keyword']])
+                            intermap.append({'keyword': i['keyword'],
+                                            'value': ival,
+                                            'title': i['title'],
+                                            'hidden': i['hidden'],
+                                            'type': i['type'],
+                                            'unit': i['unit']})
+                        else:
+                            intermap.append(i)
+                    an.setInterimFields(intermap)
+                    self.assertEqual(an.getInterimFields(), intermap)
+
+                # Let's go.. calculate and check result
+                calcanalysis.calculateResult(True, True)
+                self.assertEqual(calcanalysis.getFormattedResult(), case['expected_result'])
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -125,8 +125,8 @@ class TestCalculations(BikaFunctionalTestCase):
              'exresult': '10'
             },
         ]
+        # New formulas for precision testing
         self.formulas_precission = [
-            # New formulas for precision testing
             {'formula' : '[Ca]/[Mg]',
              'analyses': {'Ca':'10', 'Mg': '15'},
              'interims': {},
@@ -179,6 +179,111 @@ class TestCalculations(BikaFunctionalTestCase):
                      },
                 ],
             },
+            {'formula' : '[Ca]/[Mg]*[IN1]',
+             'analyses': {'Ca':'100', 'Mg': '20'},
+             'interims': {'IN1':'0.12'},
+             'test_fixed_precision': [
+                {'fixed_precision': 5,
+                 'expected_result': '0.60000',
+                },
+                {'fixed_precision': 2,
+                 'expected_result': '0.60'
+                },
+                {'fixed_precision': 1,
+                 'expected_result': '0.6'
+                },
+                {'fixed_precision': 0,
+                 'expected_result': '1'
+                },
+                {'fixed_precision': -1,
+                 'expected_result': '1'
+                },
+                {'fixed_precision': -5,
+                 'expected_result': '1'
+                },
+            ],
+            'test_uncertainties_precision':[
+                    {'uncertainties': [
+                            [ 0, 10, 0.1   ],
+                            [11, 20, 0.056 ],
+                        ],
+                        'analyses': [
+                            {'Ca': '12', 'Mg': '13'},
+                            {'Ca': '12', 'Mg': '13'},
+                        ],
+                        'expected_results': [
+                            '23.2',
+                            '32.3',
+                        ]
+                    },
+                    {'uncertainties': [
+                            [ 0, 10, 0.1   ],
+                            [11, 20, 0.056 ],
+                        ],
+                    'analyses': [
+                            {'Ca': '12', 'Mg': '13'},
+                            {'Ca': '12', 'Mg': '13'},
+                        ],
+                    'expected_results': [
+                            '23.2',
+                            '32.3',
+                        ],
+                     },
+                ],
+            },
+            {'formula' : '[Ca]/[Mg]',
+             'analyses': {'Ca':'10', 'Mg': 1},
+             'interims': {},
+             'test_fixed_precision': [
+                {'fixed_precision': 5,
+                 'expected_result': '10.00000',
+                },
+                {'fixed_precision': 2,
+                 'expected_result': '10.00'
+                },
+                {'fixed_precision': 1,
+                 'expected_result': '10.0'
+                },
+                {'fixed_precision': 0,
+                 'expected_result': '10'
+                },
+                {'fixed_precision': -1,
+                 'expected_result': '10'
+                },
+                {'fixed_precision': -5,
+                 'expected_result': '10'
+                },
+            ],
+            'test_uncertainties_precision':[
+                    {'uncertainties': [
+                            [ 0, 10, 0.1   ],
+                            [11, 20, 0.056 ],
+                        ],
+                        'analyses': [
+                            {'Ca': '12', 'Mg': '13'},
+                            {'Ca': '12', 'Mg': '13'},
+                        ],
+                        'expected_results': [
+                            '23.2',
+                            '32.3',
+                        ]
+                    },
+                    {'uncertainties': [
+                            [ 0, 10, 0.1   ],
+                            [11, 20, 0.056 ],
+                        ],
+                    'analyses': [
+                            {'Ca': '12', 'Mg': '13'},
+                            {'Ca': '12', 'Mg': '13'},
+                        ],
+                    'expected_results': [
+                            '23.2',
+                            '32.3',
+                        ],
+                     },
+                ],
+            },
+
         ]
 
     def tearDown(self):
@@ -312,7 +417,8 @@ class TestCalculations(BikaFunctionalTestCase):
                             strres = f['analyses'][key].replace(operator, '')
                             self.assertEqual(an.getResult(), str(float(strres)))
                         else:
-                            self.assertEqual(an.getResult(), f['analyses'][key])
+                            # The analysis' results have to be always strings
+                            self.assertEqual(an.getResult(), str(f['analyses'][key]))
                     elif key == self.calcservice.getKeyword():
                         calcanalysis = an
 

--- a/bika/lims/tests/test_manualuncertainty.py
+++ b/bika/lims/tests/test_manualuncertainty.py
@@ -188,6 +188,14 @@ class TestManualUncertainty(BikaFunctionalTestCase):
         self.assertEqual(get_significant_digits('2'), 0)
         self.assertEqual(get_significant_digits('22'), 0)
 
+    def test_format_decimal_mark(self):
+        # testing the function bika.lims.utils.analysis.get_significant_digits()
+        from bika.lims.utils import formatDecimalMark
+        self.assertEqual(formatDecimalMark(1), '1')
+        self.assertEqual(formatDecimalMark(1.2), '1.2')
+        self.assertEqual(formatDecimalMark('1.34'), '1.34')
+        self.assertEqual(formatDecimalMark('0.0021',decimalmark=','), '0,0021')
+        self.assertEqual(formatDecimalMark('2'), '2')
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -182,21 +182,28 @@ def formatDuration(context, totminutes):
 
 
 def formatDecimalMark(value, decimalmark='.'):
-    """ Dummy method to replace decimal mark from an input string.
+    """
+        Dummy method to replace decimal mark from an input string.
         Assumes that 'value' uses '.' as decimal mark and ',' as
         thousand mark.
+        ::value:: is a string
+        ::return:: is a string with the decimal mark if needed
     """
-
     try:
-        value = float(value)
+        vvalue = float(value)
+        # continuing with 'nan' result will cause formatting to failself
+        if math.isnan(vvalue):
+            return vvalue
     except ValueError:
         return value
-
-    # continuing with 'nan' result will cause formatting to fail.
-    if math.isnan(value):
-        return value
-
-    rawval = value
+    # We have to consider the possibility of working with decimals such as
+    # X.000 where those decimals are important because of the precission
+    # and significant digits matters
+    # Using 'float' the system delete the extre desimals with 0 as a value
+    # Example: float(2.00) -> 2.0
+    # So we have to save the decimal length, this is one reason we are usnig
+    # strings for results
+    rawval = str(value)
     try:
         if decimalmark == ',':
             rawval = rawval.replace('.', '[comma]')

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -244,7 +244,8 @@ def format_numeric_result(analysis, result, decimalmark='.', sciformat=1):
                       4. The sci notation has to be formatted as a·10^b
                       5. As 4, but with super html entity for exp
                       By default 1
-    :return: the formatted result
+    :result: should be a string to preserve the decimal precision.
+    :return: the formatted result as string
     """
     try:
         result = float(result)
@@ -298,7 +299,4 @@ def format_numeric_result(analysis, result, decimalmark='.', sciformat=1):
         prec = analysis.getPrecision(result)
         prec = prec if prec else ''
         formatted = str("%%.%sf" % prec) % result
-        # We have to check if formatted is an integer using "'.' in formatted"
-        # because ".is_integer" doesn't work with X.0
-        formatted = str(int(float(formatted))) if '.' not in formatted else formatted
     return formatDecimalMark(formatted, decimalmark)

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -297,6 +297,6 @@ def format_numeric_result(analysis, result, decimalmark='.', sciformat=1):
     else:
         # Decimal notation
         prec = analysis.getPrecision(result)
-        prec = prec if prec else ''
+        prec = prec if prec > 0 else 0
         formatted = str("%%.%sf" % prec) % result
     return formatDecimalMark(formatted, decimalmark)


### PR DESCRIPTION
[JIRA](https://jira.bikalabs.com/browse/LIMS-1917)

soliva@soliva-laptop:~/dev/labsanmartin/zinstance$ bin/test -v -p -s bika.lims --suite-name='bika.lims.tests' --test='TestCalculations'
Test-module import failures:

Module: bika.lims.tests.test_doctests

TypeError: Module bika.lims.tests.test_doctests does not define any tests

Module: bika.lims.tests.test_robot

TypeError: Module bika.lims.tests.test_robot does not define any tests

Running tests at level 1
Running bika.lims.testing.BikaTestingLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.192 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.600 seconds.
  Set up bika.lims.testing.BikaTestLayer in 56.254 seconds.
  Set up bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Running:

  Ran 3 tests with 0 failures and 0 errors in 1 minutes 12.121 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaTestingLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaTestLayer in 0.011 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.061 seconds.
  Tear down plone.testing.z2.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.004 seconds.

Test-modules with import problems:
  bika.lims.tests.test_doctests
  bika.lims.tests.test_robot
