### PR TITLE
Los informes de resultados aparecen cortados.

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.publish.js
@@ -18,7 +18,7 @@ function AnalysisRequestPublishView() {
         'letter': {
                 size: 'letter',
                 dimensions: [216, 279],
-                margins:    [20, 20, 12, 20] },
+                margins:    [20, 20, 20, 20] },
     };
 
     /**


### PR DESCRIPTION
 Se ha aumentado la altura del pie de página por defecto que tiene el formato "letter".